### PR TITLE
Mirror of paypal butterfly#154

### DIFF
--- a/butterfly-cli/pom.xml
+++ b/butterfly-cli/pom.xml
@@ -49,6 +49,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.paypal.butterfly</groupId>
+            <artifactId>butterfly-metrics-file</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Mirror of paypal butterfly#154
spetratos fabiocarvalho777 
I've noticed that I can't used some extensions 'out of the box' because they need metrics and don't package it themselves and I feel like it makes sense to package at _least_ file metrics so the extensions don't just fail.
